### PR TITLE
Set up Travis CI and a tox.ini

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,7 @@
 [run]
 source = zc.zope3recipes
+parallel = true
+data_file = $COVERAGE_HOME/.coverage
 
 [paths]
 source =

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+source = zc.zope3recipes
+
+[paths]
+source =
+    zc/
+    .tox/*/lib/python*/site-packages/zc/
+    .tox/pypy*/site-packages/zc/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.py[co]
+.tox/
+*.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 *.py[co]
 .tox/
 *.egg-info
+.coverage
+.installed.cfg
+bin/
+eggs/
+develop-eggs/
+parts/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bin/
 eggs/
 develop-eggs/
 parts/
+.coverage*

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,11 @@ install:
   - pip install zope.testrunner coverage coveralls
   - pip install -e '.[tests]'
 script:
+  - export COVERAGE_HOME=$(pwd)
+  - export COVERAGE_PROCESS_START=$COVERAGE_HOME/.coveragerc
   - coverage run -m zope.testrunner --test-path=. -vc
 after_script:
+  - coverage combine
   - coverage report -m
   - coveralls
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
   - pip install zope.testrunner coverage coveralls
   - pip install -e '.[tests]'
 script:
-  - coverage run zope-testrunner --test-path=. -vc
+  - coverage run -m zope.testrunner --test-path=. -vc
 after_script:
   - coverage report -m
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: python
+dist: xenial
+python:
+  - 2.7
+install:
+  - pip install zope.testrunner coverage coveralls
+  - pip install -e '.[tests]'
+script:
+  - coverage run zope-testrunner --test-path=. -vc
+after_script:
+  - coverage report -m
+  - coveralls
+notifications:
+  email: false
+cache: pip

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include *.py
+include buildout.cfg
+recursive-include zc *.txt

--- a/README.txt
+++ b/README.txt
@@ -21,6 +21,14 @@ Releases
 ********
 
 ===================
+0.19.0 (unreleased)
+===================
+
+- Fix TypeError: <lambda>() takes no arguments (1 given) on Windows
+  with zdaemon >= 3.0.0.
+
+
+===================
 0.18.0 (2013/02/05)
 ===================
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,20 @@
+version: build-{build}-{branch}
+
+environment:
+  matrix:
+    # https://www.appveyor.com/docs/installed-software#python lists available
+    # versions
+    - PYTHON: "C:\\Python27"
+
+init:
+  - "echo %PYTHON%"
+
+install:
+  - "set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - python --version
+  - pip install tox
+
+build: off
+
+test_script:
+  - tox -e py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,9 @@ init:
 install:
   - "set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - python --version
+  # Upgrade virtualenv because the one in the Appveyor image is old and has an
+  # old bundled pip version that thinks 'zc.recipe.egg' is an egg.
+  - pip install -U virtualenv
   - pip install tox
 
 build: off

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
              ],
         },
     extras_require = dict(
-        tests = ['zdaemon', 'zc.recipe.filestorage', 'PasteScript'],
+        tests=['zdaemon >= 3.0.0', 'zc.recipe.filestorage', 'PasteScript'],
         ),
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@
 # FOR A PARTICULAR PURPOSE.
 #
 ##############################################################################
-name, version = "zc.zope3recipes", "0"
+name, version = "zc.zope3recipes", "0.19.0.dev0"
 
 import os
 from setuptools import setup, find_packages

--- a/tox.ini
+++ b/tox.ini
@@ -16,4 +16,8 @@ deps =
    coverage
 commands =
     coverage run -m zope.testrunner --test-path=. {posargs:-vc}
+    coverage combine
     coverage report -m
+setenv =
+    COVERAGE_HOME={toxinidir}
+    COVERAGE_PROCESS_START={toxinidir}/.coveragerc

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist = py27
+
+[testenv]
+deps =
+    zope.testrunner
+extras =
+    tests
+commands =
+    zope-testrunner --test-path=. {posargs:-vc}

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,8 @@ commands =
 [testenv:coverage]
 basepython = python2.7
 deps =
-   {[testenv]deps}
-   coverage
+    {[testenv]deps}
+    coverage
 commands =
     coverage run -m zope.testrunner --test-path=. {posargs:-vc}
     coverage combine
@@ -22,3 +22,9 @@ commands =
 setenv =
     COVERAGE_HOME={toxinidir}
     COVERAGE_PROCESS_START={toxinidir}/.coveragerc
+
+[testenv:py]
+platform = win32
+deps =
+    {[testenv]deps}
+    pypiwin32

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py27
 
 [testenv]
+usedevelop = true
 deps =
     zope.testrunner
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -27,4 +27,4 @@ setenv =
 platform = win32
 deps =
     {[testenv]deps}
-    pypiwin32
+    pywin32

--- a/tox.ini
+++ b/tox.ini
@@ -8,3 +8,12 @@ extras =
     tests
 commands =
     zope-testrunner --test-path=. {posargs:-vc}
+
+[testenv:coverage]
+basepython = python2.7
+deps =
+   {[testenv]deps}
+   coverage
+commands =
+    coverage run -m zope.testrunner --test-path=. {posargs:-vc}
+    coverage report -m

--- a/zc/zope3recipes/README.txt
+++ b/zc/zope3recipes/README.txt
@@ -1875,7 +1875,7 @@ rc-directory
     installed.
 
 logrotate-directory
-    The name ot the directory where logrotate configuration files should be
+    The name of the directory where logrotate configuration files should be
     installed.
 
 user

--- a/zc/zope3recipes/README.txt
+++ b/zc/zope3recipes/README.txt
@@ -1559,9 +1559,6 @@ in the buildout bin directory:
     <BLANKLINE>
     import sys
     sys.path[0:0] = [
-      '/sample-buildout/eggs/zdaemon-2.0-py2.4.egg',
-      '/sample-buildout/eggs/setuptools-0.6-py2.4.egg',
-      '/sample-buildout/eggs/ZConfig-2.3-py2.4.egg',
       '/zope3recipes',
       ]
     <BLANKLINE>
@@ -2449,9 +2446,6 @@ in a buildout configuration.
     <BLANKLINE>
     import sys
     sys.path[0:0] = [
-      join(base, 'eggs/zdaemon-pyN.N.egg'),
-      join(base, 'eggs/setuptools-pyN.N.egg'),
-      join(base, 'eggs/ZConfig-pyN.N.egg'),
       '/zope3recipes',
       ]
     <BLANKLINE>
@@ -3149,13 +3143,10 @@ paste-based instance start scripts.
     <BLANKLINE>
     import sys
     sys.path[0:0] = [
-        '/sample-buildout/demo2',
-        '/sample-buildout/eggs/PasteScript-1.7.4.2-py2.6.egg',
-        '/sample-buildout/eggs/setuptools-0.6c12dev_r88846-py2.6.egg',
-        '/sample-buildout/eggs/PasteDeploy-1.5.0-py2.6.egg',
-        '/sample-buildout/eggs/Paste-1.7.5.1-py2.6.egg',
-        '/sample-buildout/demo1',
-        ]
+      '/sample-buildout/demo2',
+      '/.../zope3recipes/lib/python.../site-packages',
+      '/sample-buildout/demo1',
+      ]
     <BLANKLINE>
     <BLANKLINE>
     import paste.script.command

--- a/zc/zope3recipes/README.txt
+++ b/zc/zope3recipes/README.txt
@@ -109,7 +109,7 @@ in ``sys.path``.  Similarly debugzope script is also changed:
     sys.path[0:0] = [
       '/sample-buildout/demo2',
       '/sample-buildout/demo1',
-      '/zope3recipes',
+      '/zc.zope3recipes',
       ]
     <BLANKLINE>
     import zope.app.twisted.main
@@ -174,7 +174,7 @@ before server is started:
     sys.path[0:0] = [
       '/sample-buildout/demo2',
       '/sample-buildout/demo1',
-      '/zope3recipes',
+      '/zc.zope3recipes',
       ]
     <BLANKLINE>
     print "Starting application server."
@@ -224,7 +224,7 @@ Now, Let's run the buildout and see what we get:
     sys.path[0:0] = [
       '/sample-buildout/demo2',
       '/sample-buildout/demo1',
-      '/zope3recipes',
+      '/zc.zope3recipes',
       ]
     <BLANKLINE>
     print "Starting debugging interaction."
@@ -289,7 +289,7 @@ Now, Let's run the buildout and see what we get:
     sys.path[0:0] = [
       '/sample-buildout/demo2',
       '/sample-buildout/demo1',
-      '/zope3recipes',
+      '/zc.zope3recipes',
       ]
     <BLANKLINE>
     import zope.app.twisted.main
@@ -380,7 +380,7 @@ Similarly, debugzope script has relative paths.
     sys.path[0:0] = [
       join(base, 'demo2'),
       join(base, 'demo1'),
-      '/zope3recipes',
+      '/zc.zope3recipes',
       ]
     <BLANKLINE>
     import zope.app.twisted.main
@@ -542,7 +542,7 @@ variables available as global variables.
       '/sample-buildout/demo2',
       '/sample-buildout/demo1',
       '/zope3/src',
-      '/zope3recipes',
+      '/zc.zope3recipes',
       ]
     <BLANKLINE>
     import zope.app.twisted.main
@@ -682,7 +682,7 @@ The debugzope script has also been modified to take this into account.
       '/sample-buildout/demo2',
       '/sample-buildout/demo1',
       '/zope3/src',
-      '/zope3recipes',
+      '/zc.zope3recipes',
       ]
     <BLANKLINE>
     import zope.app.server.main
@@ -776,7 +776,7 @@ The debugzope script also has relative paths.
       join(base, 'demo2'),
       join(base, 'demo1'),
       '/zope3/src',
-      '/zope3recipes',
+      '/zc.zope3recipes',
       ]
     <BLANKLINE>
     import zope.app.server.main
@@ -1559,7 +1559,8 @@ in the buildout bin directory:
     <BLANKLINE>
     import sys
     sys.path[0:0] = [
-      '/zope3recipes',
+      '/site-packages',
+      '/zc.zope3recipes',
       ]
     <BLANKLINE>
     import zc.zope3recipes.ctl
@@ -2446,7 +2447,8 @@ in a buildout configuration.
     <BLANKLINE>
     import sys
     sys.path[0:0] = [
-      '/zope3recipes',
+      '/site-packages',
+      '/zc.zope3recipes',
       ]
     <BLANKLINE>
     import zc.zope3recipes.ctl
@@ -3144,10 +3146,9 @@ paste-based instance start scripts.
     import sys
     sys.path[0:0] = [
       '/sample-buildout/demo2',
-      '/.../zope3recipes/lib/python.../site-packages',
       '/sample-buildout/demo1',
+      '/site-packages',
       ]
-    <BLANKLINE>
     <BLANKLINE>
     import paste.script.command
     <BLANKLINE>

--- a/zc/zope3recipes/WINDOWS.txt
+++ b/zc/zope3recipes/WINDOWS.txt
@@ -1318,6 +1318,10 @@ rc-directory
     The name of the directory where run-control scripts should be
     installed.
 
+logrotate-directory
+    The name of the directory where logrotate configuration files should be
+    installed.
+
 user
     The name of a user that processes should run as.
 
@@ -1330,6 +1334,7 @@ create a faux installation root:
     >>> mkdir(root, 'etc')
     >>> mkdir(root, 'etc', 'myapp-run')
     >>> mkdir(root, 'etc', 'init.d')
+    >>> mkdir(root, 'etc', 'logrotate.d')
 
     >>> write('buildout.cfg',
     ... '''
@@ -1369,6 +1374,7 @@ create a faux installation root:
     ... [myapp-run]
     ... etc-directory = %(root)s/etc/myapp-run
     ... rc-directory = %(root)s/etc/init.d
+    ... logrotate-directory = %(root)s/etc/logrotate.d
     ... log-directory = %(root)s/var/log/myapp-run
     ... run-directory = %(root)s/var/run/myapp-run
     ... user = zope
@@ -1419,6 +1425,12 @@ The control script is in the init.d directory:
 Note that the deployment name is added as a prefix of the control
 script name.
 
+The logrotate file is in the logrotate.d directory:
+
+    >>> ls(root, 'etc', 'logrotate.d')
+    -  myapp-run-instance
+
+
 The configuration files have changed to reflect the deployment
 locations:
 
@@ -1464,6 +1476,16 @@ locations:
         path /root/var/log/myapp-run/instance-z3.log
       </logfile>
     </eventlog>
+
+    >>> cat(root, 'etc', 'logrotate.d', 'myapp-run-instance')
+    /root/var/log/myapp-run/instance-z3.log {
+      rotate 5
+      weekly
+      postrotate
+        /root/etc/init.d/myapp-run-instance reopen_transcript
+      endscript
+    }
+
 
 Defining multiple similar instances
 -----------------------------------
@@ -1519,6 +1541,7 @@ Let's update our buildout to add a new instance:
     ... [myapp-run]
     ... etc-directory = %(root)s/etc/myapp-run
     ... rc-directory = %(root)s/etc/init.d
+    ... logrotate-directory = %(root)s/etc/logrotate.d
     ... log-directory = %(root)s/var/log/myapp-run
     ... run-directory = %(root)s/var/run/myapp-run
     ... user = zope

--- a/zc/zope3recipes/WINDOWS.txt
+++ b/zc/zope3recipes/WINDOWS.txt
@@ -1169,9 +1169,6 @@ in the buildout bin directory:
     <BLANKLINE>
     import sys
     sys.path[0:0] = [
-      '/sample-buildout/eggs/zdaemon-2.0-py2.4.egg',
-      '/sample-buildout/eggs/setuptools-0.6-py2.4.egg',
-      '/sample-buildout/eggs/ZConfig-2.3-py2.4.egg',
       '/zope3recipes',
       ]
     <BLANKLINE>

--- a/zc/zope3recipes/WINDOWS.txt
+++ b/zc/zope3recipes/WINDOWS.txt
@@ -1169,6 +1169,7 @@ in the buildout bin directory:
     <BLANKLINE>
     import sys
     sys.path[0:0] = [
+      '/site-packages',
       '/zc.zope3recipes',
       ]
     <BLANKLINE>

--- a/zc/zope3recipes/WINDOWS.txt
+++ b/zc/zope3recipes/WINDOWS.txt
@@ -91,7 +91,7 @@ in sys.path .  Similarly debugzope script is also changed:
     sys.path[0:0] = [
       '/sample-buildout/demo2',
       '/sample-buildout/demo1',
-      '/zope3recipes',
+      '/zc.zope3recipes',
       ]
     <BLANKLINE>
     import zope.app.twisted.main
@@ -249,7 +249,7 @@ variables available as global variables.
       '/sample-buildout/demo2',
       '/sample-buildout/demo1',
       '/zope3/src',
-      '/zope3recipes',
+      '/zc.zope3recipes',
       ]
     <BLANKLINE>
     import zope.app.twisted.main
@@ -389,7 +389,7 @@ The debugzope script has also been modified to take this into account.
       '/sample-buildout/demo2',
       '/sample-buildout/demo1',
       '/zope3/src',
-      '/zope3recipes',
+      '/zc.zope3recipes',
       ]
     <BLANKLINE>
     import zope.app.server.main
@@ -1169,7 +1169,7 @@ in the buildout bin directory:
     <BLANKLINE>
     import sys
     sys.path[0:0] = [
-      '/zope3recipes',
+      '/zc.zope3recipes',
       ]
     <BLANKLINE>
     import zc.zope3recipes.winctl

--- a/zc/zope3recipes/WINDOWS.txt
+++ b/zc/zope3recipes/WINDOWS.txt
@@ -79,7 +79,7 @@ The runzope script runs the Web server:
     import zope.app.twisted.main
     <BLANKLINE>
     if __name__ == '__main__':
-        zope.app.twisted.main.main()
+        sys.exit(zope.app.twisted.main.main())
 
 Here, unlike the above example the location path is not included
 in sys.path .  Similarly debugzope script is also changed:
@@ -100,7 +100,7 @@ in sys.path .  Similarly debugzope script is also changed:
     import zc.zope3recipes.debugzope
     <BLANKLINE>
     if __name__ == '__main__':
-        zc.zope3recipes.debugzope.debug(main_module=zope.app.twisted.main)
+        sys.exit(zc.zope3recipes.debugzope.debug(main_module=zope.app.twisted.main))
 
 
 Building Zope 3 Applications (from Zope 3 checkouts/tarballs)
@@ -219,7 +219,7 @@ The runzope script runs the Web server:
     import zope.app.twisted.main
     <BLANKLINE>
     if __name__ == '__main__':
-        zope.app.twisted.main.main()
+        sys.exit(zope.app.twisted.main.main())
 
 It includes in it's path the eggs we specified in the configuration
 file, along with their dependencies. Note that we haven't specified a
@@ -258,7 +258,7 @@ variables available as global variables.
     import zc.zope3recipes.debugzope
     <BLANKLINE>
     if __name__ == '__main__':
-        zc.zope3recipes.debugzope.debug(main_module=zope.app.twisted.main)
+        sys.exit(zc.zope3recipes.debugzope.debug(main_module=zope.app.twisted.main))
 
 Note that the runzope shown above uses the default, twisted-based
 server components.  It's possible to specify which set of server
@@ -321,7 +321,7 @@ The runzope script generated is identical to what we saw before:
     import zope.app.twisted.main
     <BLANKLINE>
     if __name__ == '__main__':
-        zope.app.twisted.main.main()
+        sys.exit(zope.app.twisted.main.main())
 
 We can also specify the ZServer servers explicitly:
 
@@ -377,7 +377,7 @@ different package this time:
     import zope.app.server.main
     <BLANKLINE>
     if __name__ == '__main__':
-        zope.app.server.main.main()
+        sys.exit(zope.app.server.main.main())
 
 The debugzope script has also been modified to take this into account.
 
@@ -398,7 +398,7 @@ The debugzope script has also been modified to take this into account.
     import zc.zope3recipes.debugzope
     <BLANKLINE>
     if __name__ == '__main__':
-        zc.zope3recipes.debugzope.debug(main_module=zope.app.server.main)
+        sys.exit(zc.zope3recipes.debugzope.debug(main_module=zope.app.server.main))
 
 
 Legacy Functional Testing Support
@@ -1178,12 +1178,12 @@ in the buildout bin directory:
     import zc.zope3recipes.winctl
     <BLANKLINE>
     if __name__ == '__main__':
-        zc.zope3recipes.winctl.main([
+        sys.exit(zc.zope3recipes.winctl.main([
             '/sample-buildout/parts/myapp/debugzope',
             '/sample-buildout/parts/instance/zope.conf',
             '-C', '/sample-buildout/parts/instance/zdaemon.conf',
             ]+sys.argv[1:]
-            )
+            ))
 
 Some configuration sections can include a key multiple times; the ZEO
 client section works this way.  When a key is given multiple times,

--- a/zc/zope3recipes/tests.py
+++ b/zc/zope3recipes/tests.py
@@ -12,12 +12,15 @@
 #
 ##############################################################################
 
-import re, sys, os
+import doctest
+import os
+import re
+import sys
+import unittest
 
 import zc.buildout.testing
+from zope.testing import renormalizing
 
-import unittest
-from zope.testing import doctest, renormalizing
 
 def ls_optional(dir, ignore=(), *subs):
     if subs:
@@ -34,6 +37,7 @@ def ls_optional(dir, ignore=(), *subs):
         else:
             print '- ',
         print name
+
 
 def test_ctl():
     """
@@ -270,6 +274,7 @@ def test_suite():
             optionflags = doctest.NORMALIZE_WHITESPACE+doctest.ELLIPSIS))
 
     return suite
+
 
 if __name__ == '__main__':
     unittest.main(defaultTest='test_suite')

--- a/zc/zope3recipes/tests.py
+++ b/zc/zope3recipes/tests.py
@@ -277,6 +277,13 @@ checker = renormalizing.RENormalizing([
     (re.compile(
         r"( *'/sample-buildout/eggs/(PasteScript|six|PasteDeploy|Paste)-pyN.N.egg',\n)+"
     ), "  '/site-packages',\n"),
+    # tox -e coverage does this!  I've no idea why!
+    (re.compile(
+        r"Uninstalling myapp.\n"
+        r"(Updating database.\n|)"
+        r"Installing myapp.\n"
+        r"(Generated script '/sample-buildout/parts/myapp/[^']+'\.\n)*",
+    ), "Updating myapp.\n\\1"),
 ])
 
 

--- a/zc/zope3recipes/tests.py
+++ b/zc/zope3recipes/tests.py
@@ -243,7 +243,7 @@ checker = renormalizing.RENormalizing([
     (re.compile("""['"][^\n"']+zope3recipes[^\n"']*['"],"""),
      "'/zope3recipes',"),
     (re.compile('#![^\n]+\n'), ''),
-    (re.compile('-\S+-py\d[.]\d(-\S+)?.egg'),
+    (re.compile('-[^-]+-py\d[.]\d(-\S+)?.egg'),
      '-pyN.N.egg',
     ),
     # Turn "distribute" into "setuptools" so the tests can pass with either:

--- a/zc/zope3recipes/tests.py
+++ b/zc/zope3recipes/tests.py
@@ -240,13 +240,14 @@ checker = renormalizing.RENormalizing([
     "\(maybe misspelled\?\)"
     "\n"
     ), ''),
-    (re.compile("""['"][^\n"']+zope3recipes[^\n"']*['"],"""),
-     "'/zope3recipes',"),
+    # this directory
+    (re.compile(r"""['"][^\n"']+zc\.zope3recipes['"],"""),
+     "'/zc.zope3recipes',"),
     # welp, when we do things like `tox -e coverage`, everything's in
     # .tox/coverage/lib/pythonX.Y/site-packages and that's what gets added to
     # sys.path in the generated scripts
     (re.compile("""['"][^\n"']+site-packages['"],"""),
-     "'/zope3recipes',"),
+     "'/site-packages',"),
     (re.compile('#![^\n]+\n'), ''),
     (re.compile('-[^-]+-py\d[.]\d(-\S+)?.egg'),
      '-pyN.N.egg',
@@ -262,8 +263,20 @@ checker = renormalizing.RENormalizing([
     # Running the tests under coverage changes the output ordering!  This makes
     # no sense!
     (re.compile(
-    r"(\s*'/sample-buildout/demo1',\n)(\s*'/zope3recipes',\n)"
+    r"( *'/zope3recipes',\n)( *'/sample-buildout/demo1',\n)"
     ), r'\2\1'),
+    # Running the tests with buildout + bin/test adds ZConfig and zdaemon
+    # eggs to sys.path of generated tests.  Running the tests with tox does
+    # not (because ZConfig and zdaemon are already in .../site-packages)
+    (re.compile(
+        r" *'/sample-buildout/eggs/(ZConfig|zdaemon)-pyN.N.egg',\n"
+    ), ''),
+    (re.compile(
+        r" *join\(base, 'eggs/(ZConfig|zdaemon)-pyN.N.egg'\),\n"
+    ), ''),
+    (re.compile(
+        r"( *'/sample-buildout/eggs/(PasteScript|six|PasteDeploy|Paste)-pyN.N.egg',\n)+"
+    ), "  '/site-packages',\n"),
 ])
 
 

--- a/zc/zope3recipes/tests.py
+++ b/zc/zope3recipes/tests.py
@@ -255,23 +255,29 @@ checker = renormalizing.RENormalizing([
 
 def test_suite():
     suite = unittest.TestSuite()
+    optionflags = (
+        doctest.NORMALIZE_WHITESPACE
+        | doctest.ELLIPSIS
+        | doctest.REPORT_ONLY_FIRST_FAILURE
+        | doctest.REPORT_NDIFF
+    )
     if sys.platform[:3].lower() == "win":
         suite.addTest(doctest.DocFileSuite('WINDOWS.txt',
                  setUp=setUp,
                  tearDown=zc.buildout.testing.buildoutTearDown,
                  checker=checker,
-                 optionflags = doctest.NORMALIZE_WHITESPACE+doctest.ELLIPSIS))
+                 optionflags=optionflags))
     else:
         suite.addTest(doctest.DocTestSuite(
             setUp=setUp,
             tearDown=zc.buildout.testing.buildoutTearDown,
             checker=checker,
-            optionflags = doctest.NORMALIZE_WHITESPACE+doctest.ELLIPSIS))
+            optionflags=optionflags))
         suite.addTest(doctest.DocFileSuite('README.txt',
             setUp=setUp,
             tearDown=zc.buildout.testing.buildoutTearDown,
             checker=checker,
-            optionflags = doctest.NORMALIZE_WHITESPACE+doctest.ELLIPSIS))
+            optionflags=optionflags))
 
     return suite
 

--- a/zc/zope3recipes/tests.py
+++ b/zc/zope3recipes/tests.py
@@ -241,7 +241,7 @@ checker = renormalizing.RENormalizing([
     "\n"
     ), ''),
     # this directory
-    (re.compile(r"""['"][^\n"']+zc\.zope3recipes['"],"""),
+    (re.compile(r"""['"][^\n"']+zc.zope3recipes['"],"""),
      "'/zc.zope3recipes',"),
     # welp, when we do things like `tox -e coverage`, everything's in
     # .tox/coverage/lib/pythonX.Y/site-packages and that's what gets added to

--- a/zc/zope3recipes/tests.py
+++ b/zc/zope3recipes/tests.py
@@ -242,6 +242,11 @@ checker = renormalizing.RENormalizing([
     ), ''),
     (re.compile("""['"][^\n"']+zope3recipes[^\n"']*['"],"""),
      "'/zope3recipes',"),
+    # welp, when we do things like `tox -e coverage`, everything's in
+    # .tox/coverage/lib/pythonX.Y/site-packages and that's what gets added to
+    # sys.path in the generated scripts
+    (re.compile("""['"][^\n"']+site-packages['"],"""),
+     "'/zope3recipes',"),
     (re.compile('#![^\n]+\n'), ''),
     (re.compile('-[^-]+-py\d[.]\d(-\S+)?.egg'),
      '-pyN.N.egg',
@@ -250,7 +255,11 @@ checker = renormalizing.RENormalizing([
     (re.compile(r'\bdistribute-pyN\.N\.egg'),
      'setuptools-pyN.N.egg',
     ),
-    ])
+    # Sometimes buildout decides to also install six
+    (re.compile(
+    r"Getting distribution for 'six'\.\nGot six [0-9.]+\.\n"
+    ), ''),
+])
 
 
 def test_suite():

--- a/zc/zope3recipes/tests.py
+++ b/zc/zope3recipes/tests.py
@@ -259,6 +259,11 @@ checker = renormalizing.RENormalizing([
     (re.compile(
     r"Getting distribution for 'six'\.\nGot six [0-9.]+\.\n"
     ), ''),
+    # Running the tests under coverage changes the output ordering!  This makes
+    # no sense!
+    (re.compile(
+    r"(\s*'/sample-buildout/demo1',\n)(\s*'/zope3recipes',\n)"
+    ), r'\2\1'),
 ])
 
 

--- a/zc/zope3recipes/tests.py
+++ b/zc/zope3recipes/tests.py
@@ -300,7 +300,6 @@ def test_suite():
     optionflags = (
         doctest.NORMALIZE_WHITESPACE
         | doctest.ELLIPSIS
-        | doctest.REPORT_ONLY_FIRST_FAILURE
         | doctest.REPORT_NDIFF
     )
     if sys.platform[:3].lower() == "win":

--- a/zc/zope3recipes/tests.py
+++ b/zc/zope3recipes/tests.py
@@ -240,6 +240,8 @@ checker = renormalizing.RENormalizing([
     "\(maybe misspelled\?\)"
     "\n"
     ), ''),
+    # Windows
+    (re.compile(r'\r\n'), '\n'),
     # this directory
     (re.compile(r"""['"][^\n"']+zc.zope3recipes['"],"""),
      "'/zc.zope3recipes',"),
@@ -280,10 +282,16 @@ checker = renormalizing.RENormalizing([
     # tox -e coverage does this!  I've no idea why!
     (re.compile(
         r"Uninstalling myapp.\n"
-        r"(Updating database.\n|)"
+        r"(Updating database.\n|Installing database.\n|Uninstalling database.\n|)"
         r"Installing myapp.\n"
         r"(Generated script '/sample-buildout/parts/myapp/[^']+'\.\n)*",
-    ), "Updating myapp.\n\\1"),
+    ), "\\1Updating myapp.\n"),
+    (re.compile(
+        r"Uninstalling instance.\n"
+        r"(Updating myapp.\n|)"
+        r"Installing instance.\n"
+        r"(Generated script '/sample-buildout/bin/[^']+'\.\n)*",
+    ), "\\1Updating instance.\n"),
 ])
 
 

--- a/zc/zope3recipes/winctl.py
+++ b/zc/zope3recipes/winctl.py
@@ -211,7 +211,7 @@ class ZopectlCmd(zdaemon.zdctl.ZDCmd):
         self.proc = Popen(program)
         self.zd_pid = self.proc.pid
         self.zd_up = 1
-        self.awhile(lambda: self.zd_pid,
+        self.awhile(lambda n: self.zd_pid,
                     "Zope3 started in debug mode, pid=%(zd_pid)d")
 
     def help_debug(self):
@@ -261,7 +261,7 @@ class ZopectlCmd(zdaemon.zdctl.ZDCmd):
         self.zd_up = 0
         self.zd_pid = 0
         cpid = win32process.GetCurrentProcessId()
-        self.awhile(lambda: not getChildrenPidsOfPid(cpid), "Zope3 stopped")
+        self.awhile(lambda n: not getChildrenPidsOfPid(cpid), "Zope3 stopped")
 
     def do_kill(self, arg):
         self.do_stop(arg)
@@ -273,7 +273,7 @@ class ZopectlCmd(zdaemon.zdctl.ZDCmd):
             self.do_start(arg)
         else:
             self.do_start(arg)
-        self.awhile(lambda: self.zd_pid not in (0, pid),
+        self.awhile(lambda n: self.zd_pid not in (0, pid),
                     "Zope3 restarted, pid=%(zd_pid)d")
 
     def show_options(self):
@@ -295,7 +295,7 @@ class ZopectlCmd(zdaemon.zdctl.ZDCmd):
         self.proc = Popen(program)
         self.zd_pid = self.proc.pid
         self.zd_up = 1
-        self.awhile(lambda: self.zd_pid,
+        self.awhile(lambda n: self.zd_pid,
                     "Zope3 started, pid=%(zd_pid)d")
 
     def do_fg(self, arg):


### PR DESCRIPTION
Replace the deprecated-and-removed zope.testing.doctest with the stdlib doctest module.

Make the tests pass no matter how you run them (bin/test vs tox).

Set up Appveyor and Travis CI and Coveralls.

Fix a zdaemon compatibility problem on Windows.