### PR TITLE
Fix using the debugger inside a script called by debugzope.py.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@
 
 - Add support for Python 3.8.
 
+- Fix using the debugger inside a script called by debugzope.py.
+
 
 0.19.0 (2019-07-12)
 ===================

--- a/zc/zope3recipes/debugzope.py
+++ b/zc/zope3recipes/debugzope.py
@@ -87,7 +87,8 @@ def debug(args=None, main_module=None):
         sys.argv[:] = args
         globs['__file__'] = sys.argv[0]
         with open(sys.argv[0]) as f:
-            six.exec_(f.read(), globs)
+            code = compile(f.read(), sys.argv[0], 'exec')
+            six.exec_(code, globs)
         sys.exit()
     else:
         import code


### PR DESCRIPTION
It now is able to show the code lines again as previously `execfile` did.

Tested locally using `tox`.